### PR TITLE
fix for issue #10

### DIFF
--- a/lib/JSON/RPC/Parser.pm
+++ b/lib/JSON/RPC/Parser.pm
@@ -71,7 +71,7 @@ sub construct_from_get_req {
     my $params = $req->query_parameters;
     my $decoded_params;
     if ($params->{params}) {
-        $decoded_params = eval { $self->coder->decode( $params->{params} ) };
+        $decoded_params = eval { $self->coder->allow_nonref->decode( $params->{params} ) };
     }
     return $self->construct_procedure(
         method  => $params->{method},

--- a/t/003_parser.t
+++ b/t/003_parser.t
@@ -22,6 +22,16 @@ subtest 'basic' => sub {
     is $procedure->method, "sum", "method matches";
     is_deeply $procedure->params, [ 1, 2, 3 ], "parameters match";
 
+    # params is a top-level JSON in GET requests, it should accept strings and other nonreferences
+    $req = Plack::Request->new( {
+        QUERY_STRING   => 'method=echo&params=%22ping%2012345%22&id=1',
+        REQUEST_METHOD => "GET",
+    } );
+
+    $procedure = $parser->construct_from_req( $req );
+    ok $procedure, "procedure is defined";
+    is_deeply $procedure->params, "ping 12345", "parameters match";
+
     my $request_hash = {
         "method" => "sum",
         "params" => [1, 2, 3],

--- a/t/003_parser.t
+++ b/t/003_parser.t
@@ -29,8 +29,7 @@ subtest 'basic' => sub {
     } );
 
     $procedure = $parser->construct_from_req( $req );
-    ok $procedure, "procedure is defined";
-    is_deeply $procedure->params, "ping 12345", "parameters match";
+    is_deeply $procedure->params, "ping 12345", "string parameters match";
 
     my $request_hash = {
         "method" => "sum",


### PR DESCRIPTION
I think the problem was that JSON decoder was not expecting strings and numbers as params, as it is its default behavior. Did not have this problem in POST because params are always wrapped in a RPC request hash.